### PR TITLE
typo in triage command

### DIFF
--- a/content/docs/getting-started/triaging.md
+++ b/content/docs/getting-started/triaging.md
@@ -28,7 +28,7 @@ data from the system as possible, as quickly as possible.
 First lets see what artifacts come built in with Velociraptor:
 
 ```shell
-$ velociraptor artifact list
+$ velociraptor artifacts list
 Admin.Client.Upgrade
 Admin.Events.PostProcessUploads
 Admin.System.CompressUploads


### PR DESCRIPTION
omitted the `s` in the `artifacts` argument, doesn't work without it.